### PR TITLE
Add ARCANA_STATIC option for portable Linux binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ include(CheckSymbolExists)
 
 set(CMAKE_C_STANDARD 99)
 
+option(ARCANA_STATIC "Produce a fully static portable executable (Linux only)" OFF)
+
 add_subdirectory(Sources/Arcana)
 
 add_executable(${PROJECT_NAME} main.c)
@@ -12,16 +14,18 @@ target_include_directories(${PROJECT_NAME} PRIVATE Sources/Arcana)
 target_link_libraries(${PROJECT_NAME} arcan)
 
 CHECK_SYMBOL_EXISTS(arc4random_uniform stdlib.h HAS_ARC4RANDOM)
+set_property(GLOBAL PROPERTY HAS_ARC4RANDOM ${HAS_ARC4RANDOM})
 
-message("hasarc4random:${HAS_ARC4RANDOM}")
-
-set_property(GLOBAL PROPERTY HAS_ARC4RANDOM ${HAS_ARC4RANDOM}) 
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND NOT ${HAS_ARC4RANDOM})
-    message("no arc4random")
-    CHECK_SYMBOL_EXISTS(md5 bsd.h HAS_MD5)
-    message("hasMD5:${HAS_MD5} hasarc4random:${HAS_ARC4RANDOM}")
-    target_link_libraries(${PROJECT_NAME} bsd)
-else()
-    message("arc4random present")
-endif ()
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    if (ARCANA_STATIC)
+        message(WARNING "ARCANA_STATIC is not supported on macOS — Apple does not allow fully static binaries")
+    endif()
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    if (NOT HAS_ARC4RANDOM)
+        target_link_libraries(${PROJECT_NAME} bsd)
+    endif()
+    if (ARCANA_STATIC)
+        target_link_options(${PROJECT_NAME} PRIVATE -static)
+        message(STATUS "Static build enabled — output binary will have no runtime dependencies")
+    endif()
+endif()

--- a/README.md
+++ b/README.md
@@ -1,66 +1,245 @@
 # Arcan.a
 
-## C Static Library for the Tarot
+### A C static library for the Tarot
 
 ![Img](IMG_4612.jpeg)
 
+A cross-platform C library that generates tarot readings from a full 78-card deck. Ships with a Swift Package wrapper and two driver programs — a C CLI and a Swift CLI.
+
+---
+
+## Sample output
+
 ```
-Welcome to Arcan.a
-Your 10-card tarot reading:
-Card 1: Key 60 is in the Minor Arcana: The Paige of Swords, isInverted: 0
-Card 2: Key 45 is in the Minor Arcana: The 10 of Cups, isInverted: 1
-Card 3: Key 43 is in the Minor Arcana: The 8 of Cups, isInverted: 0
-Card 4: Key 9 is in the MAJOR ARCANA: IX: THE HERMIT, isInverted: 1
-Card 5: Key 71 is in the Minor Arcana: The 8 of Pentacles, isInverted: 1
-Card 6: Key 41 is in the Minor Arcana: The 6 of Cups, isInverted: 1
-Card 7: Key 74 is in the Minor Arcana: The Paige of Pentacles, isInverted: 1
-Card 8: Key 41 is in the Minor Arcana: The 6 of Cups, isInverted: 1
-Card 9: Key 65 is in the Minor Arcana: The 2 of Pentacles, isInverted: 1
-Card 10: Key 68 is in the Minor Arcana: The 5 of Pentacles, isInverted: 0
-Best of luck!
+~ A R C A N . A ~
+The cards await...
 
-Process finished with exit code 0
+Your significator:
+IX — THE HERMIT  (Upright)
+
+The spread is laid. Your 10-card reading:
+
+  Card 1  —  The Knight of Cups  (Reversed)
+  Card 2  —  0 — THE FOOL  (Upright)
+  Card 3  —  The VI of Swords  (Upright)
+  Card 4  —  XIV — TEMPERANCE  (Reversed)
+  Card 5  —  The Ace of Wands  (Upright)
+  Card 6  —  The X of Pentacles  (Reversed)
+  Card 7  —  III — THE EMPRESS  (Upright)
+  Card 8  —  The Queen of Cups  (Upright)
+  Card 9  —  The VIII of Swords  (Reversed)
+  Card 10 —  XVI — THE TOWER  (Reversed)
+
+May the cards light your way.
 ```
 
-### Features 
+Three-card spread (`-3`):
 
-#### Cards
+```
+Three cards rise from the dark:
 
-* Generate Deck
+  Past    —  The VI of Cups  (Upright)
+  Present —  XI — JUSTICE  (Reversed)
+  Future  —  The Ace of Swords  (Upright)
 
-* Shuffle Deck with Fisher-Yeates
+May the cards light your way.
+```
 
-* Identify card from index 0-77
+---
 
-* Randomly assign inversion for card
+## Features
 
-#### Dealing
+### Deck
+- Full 78-card deck: 22 Major Arcana + 56 Minor Arcana (4 suits × 14 cards)
+- Fisher-Yates shuffle via `arc4random_uniform`
+- Random Upright/Reversed assignment per card
+- Court card extraction as significator before shuffle
 
-* Extract chosen court card
-  * Shuffle remaining deck
-* Deal top 10 cards
+### Reading modes
+| Flag | Mode |
+|------|------|
+| *(none)* | 10-card spread, printed at once |
+| `-3` | 3-card Past / Present / Future spread |
+| `-i` | 10-card spread, one card revealed per keypress |
+| `-i -3` | 3-card spread, interactive reveal |
 
-#### API
+### Library
+- C99 static library (`libarcan.a`) — embed in any C or C++ project
+- Swift Package — import directly from Xcode or `swift build`
+- Public header exposes full deck, shuffle, deal, and reading API
 
-* Swift Package - simply hit this repo with Xcode / swiftpm
-  * `swift build` 
-  * `swift run ArcanaDriver`
+---
 
-#### Cross-platform
+## Building
 
-* Cmake Project for WSL/Linux imports `arc4random_uniform` from `bsd.h`
-* `swiftpm` system module for `bsd.h`
+### Swift Package Manager (recommended)
 
-#### Driver Program
+```sh
+swift build
+swift run ArcanaDriver
+```
 
-* Interactive CLI
-  * `getchar()` used to stagger reveal of cards.
+Run tests:
 
-#### TODO
+```sh
+swift test
+```
 
-* C Source cleanup
+On Linux, requires `libbsd-dev`:
 
-* Refine Swift Interface
-  * Wrapper to be used in GUI
+```sh
+sudo apt install libbsd-dev
+swift build
+```
 
-* Analyse reading (primarily suits / major arcana etc)
+### CMake
+
+```sh
+cmake -B build .
+cmake --build build
+./build/Arcan.a
+```
+
+#### Static binary (Linux only)
+
+Produces a self-contained executable with no runtime dependencies:
+
+```sh
+cmake -B build -DARCANA_STATIC=ON .
+cmake --build build
+```
+
+> macOS does not support fully static binaries (Apple always links `libSystem.dylib`). The flag is ignored with a warning on macOS.
+
+---
+
+## Usage
+
+```
+./Arcan.a           10-card reading
+./Arcan.a -3        Past / Present / Future reading
+./Arcan.a -i        Interactive 10-card reading (press Enter to reveal each card)
+./Arcan.a -i -3     Interactive 3-card reading
+```
+
+---
+
+## API
+
+### Types (`arcana-types.h`)
+
+```c
+typedef struct Card {
+    unsigned char index;     // 0–77
+    unsigned char inverted;  // 0 = Upright, 1 = Reversed
+} Card;
+
+typedef struct Reading {
+    Card *deck;
+    Card *courtCardForQuerant;
+    unsigned char current;   // index of next card to reveal
+    unsigned char count;     // total cards in this reading
+} Reading;
+```
+
+Card index layout:
+
+| Range | Content |
+|-------|---------|
+| 0–21 | Major Arcana (The Fool → The World) |
+| 22–35 | Wands (Ace, II–X, Page, Knight, Queen, King) |
+| 36–49 | Cups |
+| 50–63 | Swords |
+| 64–77 | Pentacles |
+
+### Functions (`arcana.h`)
+
+```c
+// Create a card by suit (0–3) and position (1–14)
+Card* makeCard(unsigned char suitIndex, unsigned char minorIndex);
+Card* getMyCard(unsigned char suitIndex, unsigned char minorIndex); // returns NULL if not a court card
+
+// Deal a shuffled 77-card deck, removing the significator
+// myCard must be a court card; returns NULL otherwise
+Card* deal(Card *myCard);
+
+// Shuffle a deck in place (Fisher-Yates)
+Card* shuffle(Card *deck);
+
+// Non-interactive readings — print all cards at once
+void readMyTarot(Card *deck);    // 10-card
+void readThreeCard(Card *deck);  // 3-card Past/Present/Future
+
+// Interactive readings — call continueReading() once per keypress
+Reading* startReading(Card *myCard, Card *deck, unsigned char count);
+unsigned char continueReading(Reading *reading); // returns 1 while cards remain, 0 when done
+
+// Card display
+void identifyCard(Card *card);          // prints name and Upright/Reversed
+unsigned char isCourtCard(Card *card);  // Page, Knight, Queen, King
+
+// String lookups
+const char* getMajorString(unsigned int cardNumber);  // e.g. "IX — THE HERMIT"
+const char* getMinorString(unsigned int suitIndex);   // e.g. "VI", "Knight"
+const char* getSuit(unsigned int suitIndex);          // e.g. "Cups"
+
+// Validation
+unsigned char validateCard(Card *card);
+unsigned char getIndex(unsigned char suitIndex, unsigned char minorIndex);
+
+// CLI config
+ArcanaConfig getConfig(int argc, const char *argv[]);
+```
+
+### Memory ownership
+
+| Function | Caller must `free()` |
+|----------|----------------------|
+| `makeCard` | yes |
+| `getMyCard` | yes (if non-NULL) |
+| `deal` | yes |
+| `startReading` | yes |
+
+---
+
+## Architecture
+
+```
+Sources/
+├── Arcana/              C static library (libarcan.a)
+│   ├── arcana-types.h   Structs, enums, constants
+│   ├── arcana.h         Public API
+│   ├── arcana.c         Implementation
+│   └── CMakeLists.txt
+├── ArcanaDriver/        Swift CLI driver
+│   └── main.swift
+├── ArcanaTests/         XCTest suite
+│   └── ArcanaTests.swift
+└── linux-lbsd/          SwiftPM system module shim for libbsd
+    ├── module.modulemap
+    └── cbsd-bridging.h
+main.c                   C CLI driver (CMake target)
+CMakeLists.txt
+Package.swift
+```
+
+---
+
+## Cross-platform notes
+
+| Platform | `arc4random_uniform` source | Notes |
+|----------|-----------------------------|-------|
+| macOS | `<stdlib.h>` | No extra dependencies |
+| Linux (modern) | `<stdlib.h>` (glibc ≥ 2.36) | No extra dependencies |
+| Linux (older) | `<bsd/bsd.h>` via `libbsd` | Install `libbsd-dev` |
+| WSL | Same as Linux | |
+
+CMake auto-detects which case applies via `CheckSymbolExists`.
+
+---
+
+## TODO
+
+- Expand test coverage across all card operations and reading flows
+- Analyse reading composition (suit balance, Major Arcana weight)
+- Refine Swift interface for use in a GUI layer


### PR DESCRIPTION
Pass -DARCANA_STATIC=ON to cmake to produce a fully static executable with no runtime dependencies. macOS is unaffected (arc4random is in stdlib and Apple does not permit fully static binaries).